### PR TITLE
AsyncCall's .when() functionality for conditioned execution

### DIFF
--- a/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
+++ b/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
@@ -30,7 +30,7 @@ public class AsyncCall<R> {
 	private final OrderedMap<Class<? extends Exception>, ExceptionCallback>
 			exCallbacks = new OrderedMap<>();
 	private boolean called = false;
-	private volatile boolean cancelled = false;
+	private volatile boolean cancelled = false, done = false;
 	private BooleanSupplier condition = null;
 
 	private long retryDelay;
@@ -545,8 +545,7 @@ public class AsyncCall<R> {
 			retry = false;
 			try {
 				R value = call.execute();
-				if(callback != null
-						&& !cancelled
+				if(callback != null && !cancelled
 						&& (condition == null || condition.getAsBoolean()))
 					callback.accept(value);
 			} catch(Exception ex) {
@@ -564,25 +563,39 @@ public class AsyncCall<R> {
 				}
 			}
 		} while(retry && !cancelled);
+
+		synchronized(this) {
+			done = true;
+			notifyAll();
+		}
 	}
 
 	/**
 	 * Executes the async call
 	 */
-	public void execute() {
+	public AsyncCall<R> execute() {
 		called = true;
 
 		if(cancelled)
-			return;
+			return this;
 
 		manager.getExecutor().execute(this::run);
+		return this;
+	}
+
+	public synchronized void join() {
+		if(done)
+			return;
+		try {
+			wait();
+		} catch(InterruptedException ignored) {}
 	}
 
 	@SuppressWarnings("deprecation")
 	@Override
 	protected void finalize() {
 		if(!called)
-			manager.getLogger().error("AsyncCaller was destroyed without ever being executed !",
+			manager.getLogger().error("AsyncCaller was destroyed without ever being executed",
 					tracker.get());
 	}
 

--- a/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
+++ b/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
@@ -8,6 +8,7 @@ import com.winteralexander.gdx.utils.error.Tracker;
 import com.winteralexander.gdx.utils.log.Logger;
 import com.winteralexander.gdx.utils.log.NullLogger;
 
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 import static com.winteralexander.gdx.utils.Validation.ensureNotNull;
@@ -30,6 +31,7 @@ public class AsyncCall<R> {
 			exCallbacks = new OrderedMap<>();
 	private boolean called = false;
 	private volatile boolean cancelled = false;
+	private BooleanSupplier condition = null;
 
 	private long retryDelay;
 
@@ -527,6 +529,11 @@ public class AsyncCall<R> {
 		return this;
 	}
 
+	public AsyncCall<R> when(BooleanSupplier condition) {
+		this.condition = condition;
+		return this;
+	}
+
 	public void cancel() {
 		cancelled = true;
 	}
@@ -538,17 +545,19 @@ public class AsyncCall<R> {
 			retry = false;
 			try {
 				R value = call.execute();
-				if(callback != null && !cancelled)
+				if(callback != null
+						&& !cancelled
+						&& (condition == null || condition.getAsBoolean()))
 					callback.accept(value);
 			} catch(Exception ex) {
-				if(!cancelled) {
+				if(!cancelled && (condition == null || condition.getAsBoolean())) {
 					StackTracker.appendFullStack(ex);
 					retry = dispatch(ex);
 					if(retry)
 						SystemUtil.sleepIfRequired(retryDelay);
 				}
 			} finally {
-				if(!retry && !cancelled) {
+				if(!retry && !cancelled && (condition == null || condition.getAsBoolean())) {
 					if(finallyCallback != null)
 						finallyCallback.accept(null);
 					StackTracker.exit(tracker);

--- a/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
+++ b/src/main/java/com/winteralexander/gdx/utils/async/AsyncCall.java
@@ -29,9 +29,10 @@ public class AsyncCall<R> {
 	private Consumer<Void> finallyCallback;
 	private final OrderedMap<Class<? extends Exception>, ExceptionCallback>
 			exCallbacks = new OrderedMap<>();
+	private BooleanSupplier condition = null;
+
 	private boolean called = false;
 	private volatile boolean cancelled = false, done = false;
-	private BooleanSupplier condition = null;
 
 	private long retryDelay;
 
@@ -583,12 +584,9 @@ public class AsyncCall<R> {
 		return this;
 	}
 
-	public synchronized void join() {
-		if(done)
-			return;
-		try {
+	public synchronized void join() throws InterruptedException {
+		while(!done)
 			wait();
-		} catch(InterruptedException ignored) {}
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
+++ b/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
@@ -38,9 +38,7 @@ public class AsyncCallTest {
 				.execute()
 				.join();
 
-		async((AsyncCall.CheckedVoidFunction<Long>)(value -> {
-			throw new RuntimeException("Fail");
-		}), 10L)
+		async(() -> { throw new RuntimeException("Fail"); })
 				.when(() -> conditionFlag.get() == true)
 				.then(v -> fail("Function that always throws should never enter .then()"))
 				.except(RuntimeException.class,

--- a/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
+++ b/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
@@ -1,0 +1,42 @@
+package com.winteralexander.gdx.utils.test.async;
+
+import com.winteralexander.gdx.utils.async.AsyncCall;
+import com.winteralexander.gdx.utils.property.MutableBox;
+import org.junit.Test;
+
+import static com.winteralexander.gdx.utils.async.AsyncCall.async;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+/**
+ * Unit test for {@link AsyncCall}
+ * <p>
+ * Created on 2026-05-01.
+ *
+ * @author Alexander Winter
+ */
+public class AsyncCallTest {
+	@Test
+	public void testWhen() {
+		MutableBox<Boolean> box = new MutableBox<>(true);
+		MutableBox<String> result = new MutableBox<>();
+		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 1000L)
+		.when(() -> box.get() == true)
+		.then(v -> {
+			result.set("Success");
+		})
+		.execute();
+
+		assertEquals("Success", result.get());
+
+		box.set(false);
+
+		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 1000L)
+		.when(() -> box.get() == true)
+		.then(v -> {
+			fail("When should protect this call");
+		})
+		.execute();
+
+	}
+}

--- a/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
+++ b/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
@@ -18,25 +18,35 @@ import static org.junit.Assert.fail;
 public class AsyncCallTest {
 	@Test
 	public void testWhen() {
-		MutableBox<Boolean> box = new MutableBox<>(true);
+		MutableBox<Boolean> conditionFlag = new MutableBox<>(true);
 		MutableBox<String> result = new MutableBox<>();
-		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 1000L)
-		.when(() -> box.get() == true)
-		.then(v -> {
-			result.set("Success");
-		})
-		.execute();
 
-		assertEquals("Success", result.get());
+		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 10L)
+				.when(() -> conditionFlag.get() == true)
+				.then(v -> result.set("A"))
+				.always(() -> result.set(result.get() + "B"))
+				.execute()
+				.join();
 
-		box.set(false);
+		assertEquals("AB", result.get());
 
-		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 1000L)
-		.when(() -> box.get() == true)
-		.then(v -> {
-			fail("When should protect this call");
-		})
-		.execute();
+		conditionFlag.set(false);
 
+		async((AsyncCall.CheckedVoidFunction<Long>)Thread::sleep, 10L)
+				.when(() -> conditionFlag.get() == true)
+				.then(v -> fail(".when() should protect against this call"))
+				.execute()
+				.join();
+
+		async((AsyncCall.CheckedVoidFunction<Long>)(value -> {
+			throw new RuntimeException("Fail");
+		}), 10L)
+				.when(() -> conditionFlag.get() == true)
+				.then(v -> fail("Function that always throws should never enter .then()"))
+				.except(RuntimeException.class,
+						ex -> fail(".when() should protect against this call"))
+				.always(() -> fail(".when() should protect against this call"))
+				.execute()
+				.join();
 	}
 }

--- a/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
+++ b/src/test/java/com/winteralexander/gdx/utils/test/async/AsyncCallTest.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.fail;
  */
 public class AsyncCallTest {
 	@Test
-	public void testWhen() {
+	public void testWhen() throws InterruptedException {
 		MutableBox<Boolean> conditionFlag = new MutableBox<>(true);
 		MutableBox<String> result = new MutableBox<>();
 


### PR DESCRIPTION
Many async call are meant to be executed when a specific condition is met, e.g. the current user is logged. The .when() functionality offers an easy way to protect the body of these calls when the user logs out instead of having to store async calls to cancel them or copy identical "if logged" logic in all async call bodies across the app.