### PR TITLE
Restore no-throw behavior for GdxCallback 

### DIFF
--- a/src/main/java/com/winteralexander/gdx/utils/async/GdxCallback.java
+++ b/src/main/java/com/winteralexander/gdx/utils/async/GdxCallback.java
@@ -18,7 +18,8 @@ public interface GdxCallback<T> extends Consumer<T> {
 
 	@Override
 	default void accept(T value) {
-		GdxUtil.postRunnable(() -> receive(value));
+		if(GdxUtil.isRunning())
+			GdxUtil.postRunnable(() -> receive(value));
 	}
 
 	void receive(T t);


### PR DESCRIPTION
as its not desirable to receive the exception within AsyncCall stuff