### PR TITLE
Fixing bad arguments for functions in CollectionUtil

### DIFF
--- a/src/main/java/com/winteralexander/gdx/utils/collection/CollectionUtil.java
+++ b/src/main/java/com/winteralexander/gdx/utils/collection/CollectionUtil.java
@@ -6,6 +6,7 @@ import com.winteralexander.gdx.utils.function.FloatPredicate;
 import com.winteralexander.gdx.utils.collection.iterator.JavaArrayIndexIterator;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.function.DoublePredicate;
 import java.util.function.Function;
 import java.util.function.IntPredicate;
@@ -209,6 +210,33 @@ public class CollectionUtil {
 	}
 
 	/**
+	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
+	 * The alternate overload is prefered.
+	 * @see CollectionUtil#any(Iterable, Predicate)
+	 */
+	public static <T> boolean areAny(Iterable<T> array,
+			com.badlogic.gdx.utils.Predicate<T> predicate) {
+		for(T element : array)
+			if(predicate.evaluate(element))
+				return true;
+
+		return false;
+	}
+
+	/**
+	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
+	 * The alternate overload is prefered.
+	 * @see CollectionUtil#any(T[], Predicate)
+	 */
+	public static <T> boolean areAny(T[] array, com.badlogic.gdx.utils.Predicate<T> predicate) {
+		for(T element : array)
+			if(predicate.evaluate(element))
+				return true;
+
+		return false;
+	}
+
+	/**
 	 * Evaluates elements of an array and returns true if any of the element match the specified
 	 * predicate. May not evaluate all elements if one is found to be true early.
 	 *
@@ -219,7 +247,7 @@ public class CollectionUtil {
 	 */
 	public static <T> boolean any(Iterable<T> array, Predicate<T> predicate) {
 		for(T element : array)
-			if(predicate.evaluate(element))
+			if(predicate.test(element))
 				return true;
 
 		return false;
@@ -236,7 +264,7 @@ public class CollectionUtil {
 	 */
 	public static <T> boolean any(T[] array, Predicate<T> predicate) {
 		for(T element : array)
-			if(predicate.evaluate(element))
+			if(predicate.test(element))
 				return true;
 
 		return false;
@@ -307,15 +335,25 @@ public class CollectionUtil {
 	}
 
 	/**
-	 * Evaluates elements of an array and returns true if all the elements match the specified
-	 * predicate. May not evaluate all elements if one is found to be false early.
-	 *
-	 * @param array array of elements to evaluate
-	 * @param predicate predicate to test on elements
-	 * @return true if the predicate matches all elements in the array
-	 * @param <T> type of elements
+	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
+	 * The alternate overload is prefered.
+	 * @see CollectionUtil#all(Iterable, Predicate)
 	 */
-	public static <T> boolean all(Iterable<T> array, Predicate<T> predicate) {
+	public static <T> boolean areAll(Iterable<T> array,
+			com.badlogic.gdx.utils.Predicate<T> predicate) {
+		for(T element : array)
+			if(!predicate.evaluate(element))
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
+	 * The alternate overload is prefered.
+	 * @see CollectionUtil#all(T[], Predicate)
+	 */
+	public static <T> boolean areAll(T[] array, com.badlogic.gdx.utils.Predicate<T> predicate) {
 		for(T element : array)
 			if(!predicate.evaluate(element))
 				return false;
@@ -332,9 +370,26 @@ public class CollectionUtil {
 	 * @return true if the predicate matches all elements in the array
 	 * @param <T> type of elements
 	 */
+	public static <T> boolean all(Iterable<T> array, Predicate<T> predicate) {
+		for(T element : array)
+			if(!predicate.test(element))
+				return false;
+
+		return true;
+	}
+
+	/**
+	 * Evaluates elements of an array and returns true if all the elements match the specified
+	 * predicate. May not evaluate all elements if one is found to be false early.
+	 *
+	 * @param array array of elements to evaluate
+	 * @param predicate predicate to test on elements
+	 * @return true if the predicate matches all elements in the array
+	 * @param <T> type of elements
+	 */
 	public static <T> boolean all(T[] array, Predicate<T> predicate) {
 		for(T element : array)
-			if(!predicate.evaluate(element))
+			if(!predicate.test(element))
 				return false;
 
 		return true;
@@ -674,8 +729,12 @@ public class CollectionUtil {
 		return (Iterable<T>)(Iterable)other;
 	}
 
-	public static boolean allInstanceOf(Iterable<?> iterable, Class<?> type) {
-		return all(iterable, type::isInstance);
+	public static boolean allInstancesOf(Iterable<?> iterable, Class<?> type) {
+		for(Object element : iterable)
+			if(!type.isInstance(element))
+				return false;
+
+		return true;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/src/main/java/com/winteralexander/gdx/utils/collection/CollectionUtil.java
+++ b/src/main/java/com/winteralexander/gdx/utils/collection/CollectionUtil.java
@@ -212,6 +212,10 @@ public class CollectionUtil {
 	/**
 	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
 	 * The alternate overload is prefered.
+	 * @param array array of elements to evaluate
+	 * @param predicate predicate to test on elements
+	 * @return true if the predicate matches any element in the iterable
+	 * @param <T> type of elements
 	 * @see CollectionUtil#any(Iterable, Predicate)
 	 */
 	public static <T> boolean areAny(Iterable<T> array,
@@ -226,7 +230,11 @@ public class CollectionUtil {
 	/**
 	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
 	 * The alternate overload is prefered.
-	 * @see CollectionUtil#any(T[], Predicate)
+	 * @param array array of elements to evaluate
+	 * @param predicate predicate to test on elements
+	 * @return true if the predicate matches any element in the array
+	 * @param <T> type of elements
+	 * @see CollectionUtil#any(Object[], Predicate)
 	 */
 	public static <T> boolean areAny(T[] array, com.badlogic.gdx.utils.Predicate<T> predicate) {
 		for(T element : array)
@@ -242,7 +250,7 @@ public class CollectionUtil {
 	 *
 	 * @param array array of elements to evaluate
 	 * @param predicate predicate to test on elements
-	 * @return true if the predicate matches any element in the array
+	 * @return true if the predicate matches any element in the iterable
 	 * @param <T> type of elements
 	 */
 	public static <T> boolean any(Iterable<T> array, Predicate<T> predicate) {
@@ -337,6 +345,10 @@ public class CollectionUtil {
 	/**
 	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
 	 * The alternate overload is prefered.
+	 * @param array array of elements to evaluate
+	 * @param predicate libGDX predicate to test on elements
+	 * @return true if the predicate matches all elements in the iterable
+	 * @param <T> type of elements
 	 * @see CollectionUtil#all(Iterable, Predicate)
 	 */
 	public static <T> boolean areAll(Iterable<T> array,
@@ -351,7 +363,11 @@ public class CollectionUtil {
 	/**
 	 * "Overload" that takes a libGDX Predicate. Can't be a true overload without lambda ambiguity.
 	 * The alternate overload is prefered.
-	 * @see CollectionUtil#all(T[], Predicate)
+	 * @param array array of elements to evaluate
+	 * @param predicate libGDX predicate to test on elements
+	 * @return true if the predicate matches all elements in the array
+	 * @param <T> type of elements
+	 * @see CollectionUtil#all(Object[], Predicate)
 	 */
 	public static <T> boolean areAll(T[] array, com.badlogic.gdx.utils.Predicate<T> predicate) {
 		for(T element : array)
@@ -367,7 +383,7 @@ public class CollectionUtil {
 	 *
 	 * @param array array of elements to evaluate
 	 * @param predicate predicate to test on elements
-	 * @return true if the predicate matches all elements in the array
+	 * @return true if the predicate matches all elements in the iterable
 	 * @param <T> type of elements
 	 */
 	public static <T> boolean all(Iterable<T> array, Predicate<T> predicate) {

--- a/src/test/java/com/winteralexander/gdx/utils/test/collection/CollectionUtilTest.java
+++ b/src/test/java/com/winteralexander/gdx/utils/test/collection/CollectionUtilTest.java
@@ -44,13 +44,13 @@ public class CollectionUtilTest {
 		objs.add("Henloo");
 		objs.add("Halo");
 		objs.add("Allo");
-		assertTrue(CollectionUtil.allInstanceOf(objs, String.class));
-		assertTrue(CollectionUtil.allInstanceOf(objs, CharSequence.class));
+		assertTrue(CollectionUtil.allInstancesOf(objs, String.class));
+		assertTrue(CollectionUtil.allInstancesOf(objs, CharSequence.class));
 		Iterable<String> strs = CollectionUtil.castIterable(objs);
 		Array<String> array = CollectionUtil.toGdxArray(strs);
 		assertEquals(objs, array);
 		objs.add(new Object());
-		assertFalse(CollectionUtil.allInstanceOf(objs, String.class));
+		assertFalse(CollectionUtil.allInstancesOf(objs, String.class));
 	}
 
 	@Test


### PR DESCRIPTION
All overloads to have CollectionUtil all/any support java utils Predicate (prefered), renamed original methods for libGDX Predicate. Renamed allInstanceOf to plural